### PR TITLE
Feature vec visitor

### DIFF
--- a/examples/removenotes.rs
+++ b/examples/removenotes.rs
@@ -1,0 +1,26 @@
+extern crate pandoc_ast;
+
+use pandoc_ast::{MutVisitor, Inline};
+use std::io::{self, Write, Read};
+
+struct MyVisitor;
+
+impl MutVisitor for MyVisitor {
+    fn visit_vec_inline(&mut self, vec_inline: &mut Vec<Inline>) {
+        vec_inline.retain(|inline| match inline {
+            &Inline::Note(_) => false,
+            _ => true
+        });
+        self.walk_vec_inline(vec_inline);
+    }
+}
+
+fn main() {
+    let mut s = String::new();
+    io::stdin().read_to_string(&mut s).unwrap();
+    let s = pandoc_ast::filter(s, |mut pandoc| {
+        MyVisitor.walk_pandoc(&mut pandoc);
+        pandoc
+    });
+    io::stdout().write(s.as_bytes()).unwrap();
+}


### PR DESCRIPTION
There seems to be currently no easy way to insert or remove inline or block elements without re-implementing much of the AST traversal logic.

I would assume that insertion and deletion are very frequently needed operations, see e.g. the "Removing links" example in the original Pandoc filter doc.

The additional hooks preserve backward compatibility.