### PR TITLE
Update Pandoc version to 1.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pandoc_ast"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Oliver Schneider <rust-pandoc-ast885559849564@oli-obk.de>"]
 readme = "README.md"
 keywords = ["latex", "markdown", "pandoc", "filter", "ast"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,14 @@ pub enum Block {
     HorizontalRule,
     /// Table, with attributes, caption, column alignments + widths
     /// column headers (each a list of rows), body and foot
-    Table(Attr, Caption, Vec<ColSpec>, TableHead, Vec<TableBody>, TableFoot),
+    Table(
+        Attr,
+        Caption,
+        Vec<ColSpec>,
+        TableHead,
+        Vec<TableBody>,
+        TableFoot
+    ),
     /// Generic block container with attributes
     Div(Attr, Vec<Block>),
     /// Nothing
@@ -220,7 +227,7 @@ pub type RowHeadColumns = Int;
 #[serde(tag = "t", content = "c")]
 pub enum ColWidth {
     ColWidth(Double),
-    ColWidthDefault,
+    ColWidthDefault
 }
 
 pub type ColSpec = (Alignment, ColWidth);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,12 @@ impl Pandoc {
 			 please file a bug report against `pandoc-ast` to update for the newest pandoc version"
         );
 
-        // [1.21 , 1.22]
+        // [1.21 , 1.23]
         assert!(
-            (20..23).contains(&data.pandoc_api_version[1]),
+            (20..=23).contains(&data.pandoc_api_version[1]),
             "pandoc-ast minor version mismatch: \
             please file a bug report against `pandoc-ast` to update for the newest pandoc version"
         );
-
 
         data
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,26 +24,38 @@ impl Pandoc {
     pub fn from_json(json: &str) -> Self {
         let v: serde_json::Value = from_str(json).unwrap();
         let obj = v.as_object().expect("broken pandoc json");
-        assert!(obj.contains_key("pandoc-api-version"), "Please update your pandoc to at least version 1.18 or use an older version of `pandoc-ast`");
+        fn pandoc_version(obj: &serde_json::Map<String, serde_json::Value>) -> Option<(i64, i64)> {
+            let version = obj
+                .get("pandoc-api-version")?
+                .as_array()?
+                .into_iter()
+                .map(|v| v.as_i64())
+                .collect::<Vec<_>>();
+            match version[..] {
+                [Some(major), Some(minor)] => Some((major, minor)),
+                _ => None,
+            }
+        }
+        // test pandoc version
+        if let Some((major, minor)) = pandoc_version(&obj) {
+            if !(major == 1 && minor >= 20) {
+                panic!(
+                    "Pandoc version mismatch: \
+                    `pandoc-ast` expects pandoc version 1.20 or newer, got {}.{}",
+                    major, minor
+                );
+            }
+        } else {
+            panic!(
+                "Unable to parse pandoc version from JSON. \
+                Please update your pandoc to at least version 1.18 or use an older version of `pandoc-ast`"
+            );
+        }
         let s = serde_json::to_string_pretty(&v).unwrap();
         let data: Self = match from_str(&s) {
             Ok(data) => data,
             Err(err) => panic!("json is not in the pandoc format: {:?}\n{}", err, s),
         };
-        //test major version
-        assert_eq!(
-            data.pandoc_api_version[0], 1,
-            "pandoc-ast minor version mismatch: \
-			 please file a bug report against `pandoc-ast` to update for the newest pandoc version"
-        );
-
-        // [1.21 , 1.23]
-        assert!(
-            (20..=23).contains(&data.pandoc_api_version[1]),
-            "pandoc-ast minor version mismatch: \
-            please file a bug report against `pandoc-ast` to update for the newest pandoc version"
-        );
-
         data
     }
 
@@ -90,14 +102,7 @@ pub enum Block {
     HorizontalRule,
     /// Table, with attributes, caption, column alignments + widths
     /// column headers (each a list of rows), body and foot
-    Table(
-        Attr,
-        Caption,
-        Vec<ColSpec>,
-        TableHead,
-        Vec<TableBody>,
-        TableFoot
-    ),
+    Table(Attr, Caption, Vec<ColSpec>, TableHead, Vec<TableBody>, TableFoot),
     /// Generic block container with attributes
     Div(Attr, Vec<Block>),
     /// Nothing
@@ -215,7 +220,7 @@ pub type RowHeadColumns = Int;
 #[serde(tag = "t", content = "c")]
 pub enum ColWidth {
     ColWidth(Double),
-    ColWidthDefault
+    ColWidthDefault,
 }
 
 pub type ColSpec = (Alignment, ColWidth);


### PR DESCRIPTION
I'm not sure whether abolishing Pandoc version check upper bound would be beneficial in the long term 🤔

Right now, every time there is a new Pandoc release this library has to be manually updated, regardless of there being breaking changes or not. Maybe a better aproach would be to to panic only if filter's JSON can't be deserialized properly.