### PR TITLE
fix: Ignore patch version when checking for compatible versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl Pandoc {
                 .map(|v| v.as_i64())
                 .collect::<Vec<_>>();
             match version[..] {
-                [Some(major), Some(minor)] => Some((major, minor)),
+                [Some(major), Some(minor), ..] => Some((major, minor)),
                 _ => None,
             }
         }


### PR DESCRIPTION
when checking for compatible versions only Major and Minor versions should be checked. having a pandoc version with patch and or revision(?) version numbers in the API version previously caused a crash

This fixes #15 