### PR TITLE
Improve Pandoc version incompatibility error messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,18 +34,23 @@ impl Pandoc {
             }
         }
         // test pandoc version
+        const REQUIRED_PANDOC_VERSION: &str = "2.8";
         if let Some((major, minor)) = pandoc_version(obj) {
-            if !(major == 1 && minor >= 20) {
+            let (required_major, required_minor) = (1, 20);
+            if !(major == required_major && minor >= required_minor) {
                 panic!(
                     "Pandoc version mismatch: \
-                    `pandoc-ast` expects pandoc version 1.20 or newer, got {}.{}",
-                    major, minor
+                    `pandoc-ast` expects Pandoc AST version {}.{} or newer \
+                    (`pandoc` {} or newer), got {}.{}",
+                    required_major, required_minor, REQUIRED_PANDOC_VERSION, major, minor
                 );
             }
         } else {
             panic!(
-                "Unable to parse pandoc version from JSON. \
-                Please update your pandoc to at least version 1.18 or use an older version of `pandoc-ast`"
+                "Unable to parse Pandoc AST version from JSON. \
+                Please update your pandoc to at least version {} \
+                or use an older version of `pandoc-ast`",
+                REQUIRED_PANDOC_VERSION
             );
         }
         let s = serde_json::to_string_pretty(&v).unwrap();


### PR DESCRIPTION
https://github.com/oli-obk/pandoc-ast/blob/e99d773fe53f5fde3c4fd903cab6950f9db33b98/src/lib.rs#L36-L50

The first message says that `1.20` is required, while the second says `1.18`. I'm assuming `1.20` is intended since that's what the code checks.

Also, the version this is checking is Pandoc's AST version (the version of the [`pandoc-types` package](https://hackage.haskell.org/package/pandoc-types)), which is versioned separately from [`pandoc`](https://hackage.haskell.org/package/pandoc). This clarifies that and states the corresponding minimum Pandoc version (`2.8` assuming the `1.20` AST version requirement is the correct one).